### PR TITLE
[NIT] Add support for old version of Metabase

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,12 +13,13 @@ docker build -t formal-metabase-sync-worker .
 Then run the docker image:
 
 ```bash
-docker run -e METABASE_HOSTNAME=""  -e METABASE_USERNAME="" -e METABASE_PASSWORD="" -e FORMAL_API_KEY="" -e FORMAL_APP_ID="" formal-metabase-sync-worker
+docker run -e METABASE_HOSTNAME=""  -e METABASE_USERNAME="" -e METABASE_PASSWORD="" -e METABASE_VERSION="" -e FORMAL_API_KEY="" -e FORMAL_APP_ID="" formal-metabase-sync-worker
 ```
 
 ## Environment Variables
 - ```METABASE_HOSTNAME```: The hostname of the metabase instance 
 - ```METABASE_USERNAME```: The username of the metabase instance
 - ```METABASE_PASSWORD```: The password of the metabase instance
+- ```METABASE_VERSION```: The version of the metabase instance (e.g.: 0.35.4)
 - ```FORMAL_API_KEY```: The API key of the formal instance
 - ```FORMAL_APP_ID```: The app id of the Formal Metabase integration

--- a/main.go
+++ b/main.go
@@ -11,6 +11,7 @@ func main() {
 		MetabaseHostname: os.Getenv("METABASE_HOSTNAME"),
 		MetabaseUsername: os.Getenv("METABASE_USERNAME"),
 		MetabasePwd:      os.Getenv("METABASE_PASSWORD"),
+		Version:          os.Getenv("METABASE_VERSION"),
 	}
 	formalAPIKey := os.Getenv("FORMAL_API_KEY")
 	integrationID := os.Getenv("FORMAL_APP_ID")

--- a/metabase_api.go
+++ b/metabase_api.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"io"
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 
@@ -26,46 +27,95 @@ type MetabaseUser struct {
 	IsActive bool   `json:"is_active"`
 }
 
-func GetMetabaseRoles(hostname, sessionKey string) (map[string]MetabaseUser, error) {
+const METABASE_THRESHOLD_VERSION = "0.36"
+
+func GetMetabaseRoles(hostname, metabaseVersion, sessionKey string) (map[string]MetabaseUser, error) {
 	baseUrl := "https://" + hostname + "/api/user"
 
 	roles := map[string]MetabaseUser{}
-	req, err := http.NewRequest("GET", baseUrl, nil)
-	if err != nil {
-		return nil, err
-	}
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("X-Metabase-Session", sessionKey)
+	// In newer version of Metabase, the User API is paginated so the returned data is different, hence the difference of logic based on the version
+	if metabaseVersion > METABASE_THRESHOLD_VERSION {
+		total := 1
+		for len(roles) < total {
+			url := baseUrl + "?offset=" + strconv.Itoa(len(roles))
+			req, err := http.NewRequest("GET", url, nil)
+			if err != nil {
+				return nil, err
+			}
+			req.Header.Set("Content-Type", "application/json")
+			req.Header.Set("X-Metabase-Session", sessionKey)
 
-	// Send Request
-	client := http.Client{Timeout: 30 * time.Second}
-	resp, err := client.Do(req)
-	if err != nil {
-		return nil, err
-	}
+			// Send Request
+			client := http.Client{Timeout: 30 * time.Second}
+			resp, err := client.Do(req)
+			if err != nil {
+				return nil, err
+			}
 
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		log.Error().Err(err).Msg("LOC getMetabaseRoles cannot read body")
-		return nil, err
-	}
-	defer resp.Body.Close()
+			body, err := io.ReadAll(resp.Body)
+			if err != nil {
+				log.Error().Err(err).Msg("LOC getMetabaseRoles cannot read body")
+				return nil, err
+			}
+			defer resp.Body.Close()
 
-	var users []MetabaseUser
-	err = json.Unmarshal(body, &users)
-	if err != nil {
-		log.Error().Err(err).Msg("Error in getMetabaseRoles - cannot unmarshal body")
+			var users []MetabaseUser
+			var response MetabaseUsersResponse
+			err = json.Unmarshal(body, &response)
+			if err != nil {
+				log.Error().Err(err).Msg("Error in getMetabaseRoles - cannot unmarshal body")
+				err = json.Unmarshal(body, &users)
+				if err != nil {
+					log.Error().Err(err).Msg("Error in getMetabaseRoles - cannot unmarshal body")
+					return nil, err
+				}
+			} else {
+				users = response.Data
+			}
+
+			for _, user := range users {
+				roles[user.Email] = user
+			}
+
+			total = response.Total
+		}
+	} else {
+		req, err := http.NewRequest("GET", baseUrl, nil)
+		if err != nil {
+			return nil, err
+		}
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("X-Metabase-Session", sessionKey)
+
+		// Send Request
+		client := http.Client{Timeout: 30 * time.Second}
+		resp, err := client.Do(req)
+		if err != nil {
+			return nil, err
+		}
+
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			log.Error().Err(err).Msg("LOC getMetabaseRoles cannot read body")
+			return nil, err
+		}
+		defer resp.Body.Close()
+
+		var users []MetabaseUser
 		err = json.Unmarshal(body, &users)
 		if err != nil {
 			log.Error().Err(err).Msg("Error in getMetabaseRoles - cannot unmarshal body")
-			return nil, err
+			err = json.Unmarshal(body, &users)
+			if err != nil {
+				log.Error().Err(err).Msg("Error in getMetabaseRoles - cannot unmarshal body")
+				return nil, err
+			}
+		}
+
+		for _, user := range users {
+			roles[user.Email] = user
 		}
 	}
-
-	for _, user := range users {
-		roles[user.Email] = user
-	}
-
 	return roles, nil
 }
 

--- a/workflow.go
+++ b/workflow.go
@@ -10,6 +10,7 @@ type MetabaseIntegration struct {
 	MetabaseHostname string
 	MetabaseUsername string
 	MetabasePwd      string
+	Version          string
 }
 
 func MetabaseWorkflow(metabaseIntegration MetabaseIntegration, apiKey, integrationID string) error {
@@ -20,7 +21,7 @@ func MetabaseWorkflow(metabaseIntegration MetabaseIntegration, apiKey, integrati
 		return err
 	}
 
-	metabaseRoles, err := GetMetabaseRoles(metabaseIntegration.MetabaseHostname, sessionKey)
+	metabaseRoles, err := GetMetabaseRoles(metabaseIntegration.MetabaseHostname, metabaseIntegration.Version, sessionKey)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Context

In older version of Metabase, the API returned an array of users (no pagination).

## Problem
A customer running an old version of Metabase would have the following error:
```
{"level":"error","error":"json: cannot unmarshal array into Go value of type main.MetabaseUsersResponse","time":"2024-02-19T09:23:18Z","message":"Error in getMetabaseRoles - cannot unmarshal body"}
{"level":"fatal","error":"unknown: Unauthorized","time":"2024-02-19T09:23:18Z","message":"Error in MetabaseWorkflow"}
```

Since we assumed that the API returned an object instead of an array, the app would crash.

## Solution
To support older versions, a new env parameter has been added `METABASE_VERSION`.

The customer now needs to provide the version they are running and based on the version, the logic will be different. 