### PR TITLE
Add Cloudflare Access headers support for Metabase API requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ docker build -t formal-metabase-sync-worker .
 Then run the docker image:
 
 ```bash
-docker run -e METABASE_HOSTNAME="" -e METABASE_USE_API_KEY="" -e METABASE_API_KEY=""  -e METABASE_USERNAME="" -e METABASE_PASSWORD="" -e METABASE_VERSION="" -e FORMAL_API_KEY="" -e FORMAL_APP_ID="" -e VERIFY_TLS="" formal-metabase-sync-worker 
+docker run -e METABASE_HOSTNAME="" -e METABASE_USE_API_KEY="" -e METABASE_API_KEY=""  -e METABASE_USERNAME="" -e METABASE_PASSWORD="" -e METABASE_VERSION="" -e FORMAL_API_KEY="" -e FORMAL_APP_ID="" -e VERIFY_TLS="" -e CF_ACCESS_CLIENT_ID="" -e CF_ACCESS_CLIENT_SECRET="" formal-metabase-sync-worker 
 ```
 
 ## Environment Variables
@@ -26,5 +26,7 @@ docker run -e METABASE_HOSTNAME="" -e METABASE_USE_API_KEY="" -e METABASE_API_KE
 - ```FORMAL_API_KEY```: The API key of the formal instance
 - ```FORMAL_APP_ID```: The app id of the Formal Metabase integration
 - ```VERIFY_TLS```: Whether or not to verify the TLS certificate of the Metabase instance. Set to `true` or `false`
+- ```CF_ACCESS_CLIENT_ID``` (optional): Cloudflare Access Client ID for bypassing Cloudflare Access protection on Metabase instances
+- ```CF_ACCESS_CLIENT_SECRET``` (optional): Cloudflare Access Client Secret for bypassing Cloudflare Access protection on Metabase instances
 - ```LOG_LEVEL``` (optional): Set the Global logging level to any of these options: `debug`, `info`, `warn`, `error`, `fatal`, `panic`, `disabled`. Default value is `info`.
 - ```FREQUENCY``` (optional): The frequency at which to run the sync. Expected format: `1h`, `30m`, etc. If not provided, the sync will run once and then exit.

--- a/main.go
+++ b/main.go
@@ -62,8 +62,12 @@ func main() {
 		}
 	}
 
+	// Cloudflare Access headers
+	cfAccessClientID := os.Getenv("CF_ACCESS_CLIENT_ID")
+	cfAccessClientSecret := os.Getenv("CF_ACCESS_CLIENT_SECRET")
+
 	for {
-		err = MetabaseWorkflow(metabaseIntegration, formalAPIKey, integrationID, verifyTLS)
+		err = MetabaseWorkflow(metabaseIntegration, formalAPIKey, integrationID, verifyTLS, cfAccessClientID, cfAccessClientSecret)
 		if err != nil {
 			log.Error().Err(err).Msg("Error in MetabaseWorkflow")
 		}

--- a/metabase_api.go
+++ b/metabase_api.go
@@ -30,7 +30,7 @@ type MetabaseUser struct {
 
 const METABASE_THRESHOLD_VERSION = "0.40.0"
 
-func GetMetabaseRoles(hostname string, metabaseVersion string, apiKey string, sessionKey string, useAPIKey bool, verifyTLS bool) (map[string]MetabaseUser, error) {
+func GetMetabaseRoles(hostname string, metabaseVersion string, apiKey string, sessionKey string, useAPIKey bool, verifyTLS bool, cfAccessClientID, cfAccessClientSecret string) (map[string]MetabaseUser, error) {
 	baseUrl := "https://" + hostname + "/api/user"
 
 	roles := map[string]MetabaseUser{}
@@ -48,6 +48,13 @@ func GetMetabaseRoles(hostname string, metabaseVersion string, apiKey string, se
 				req.Header.Set("X-API-Key", apiKey)
 			} else {
 				req.Header.Set("X-Metabase-Session", sessionKey)
+			}
+			// Add Cloudflare Access headers if provided
+			if cfAccessClientID != "" {
+				req.Header.Set("CF-Access-Client-Id", cfAccessClientID)
+			}
+			if cfAccessClientSecret != "" {
+				req.Header.Set("CF-Access-Client-Secret", cfAccessClientSecret)
 			}
 
 			// Send Request
@@ -100,6 +107,13 @@ func GetMetabaseRoles(hostname string, metabaseVersion string, apiKey string, se
 		} else {
 			req.Header.Set("X-Metabase-Session", sessionKey)
 		}
+		// Add Cloudflare Access headers if provided
+		if cfAccessClientID != "" {
+			req.Header.Set("CF-Access-Client-Id", cfAccessClientID)
+		}
+		if cfAccessClientSecret != "" {
+			req.Header.Set("CF-Access-Client-Secret", cfAccessClientSecret)
+		}
 
 		// Send Request
 		client := &http.Client{
@@ -138,7 +152,7 @@ func GetMetabaseRoles(hostname string, metabaseVersion string, apiKey string, se
 	return roles, nil
 }
 
-func RefreshMetabaseSessionKey(integration MetabaseIntegration, verifyTLS bool) (string, error) {
+func RefreshMetabaseSessionKey(integration MetabaseIntegration, verifyTLS bool, cfAccessClientID, cfAccessClientSecret string) (string, error) {
 	url := "https://" + integration.MetabaseHostname + "/api/session"
 
 	payload := map[string]string{
@@ -155,6 +169,13 @@ func RefreshMetabaseSessionKey(integration MetabaseIntegration, verifyTLS bool) 
 		return "", err
 	}
 	req.Header.Set("Content-Type", "application/json")
+	// Add Cloudflare Access headers if provided
+	if cfAccessClientID != "" {
+		req.Header.Set("CF-Access-Client-Id", cfAccessClientID)
+	}
+	if cfAccessClientSecret != "" {
+		req.Header.Set("CF-Access-Client-Secret", cfAccessClientSecret)
+	}
 
 	// Send Request
 	client := &http.Client{

--- a/workflow.go
+++ b/workflow.go
@@ -15,13 +15,13 @@ type MetabaseIntegration struct {
 	Version          string
 }
 
-func MetabaseWorkflow(metabaseIntegration MetabaseIntegration, apiKey, integrationID string, verifyTLS bool) error {
+func MetabaseWorkflow(metabaseIntegration MetabaseIntegration, apiKey, integrationID string, verifyTLS bool, cfAccessClientID, cfAccessClientSecret string) error {
 	client := New(apiKey)
 
 	sessionKey := ""
 
 	if !metabaseIntegration.UseAPIKey {
-		key, err := RefreshMetabaseSessionKey(metabaseIntegration, verifyTLS)
+		key, err := RefreshMetabaseSessionKey(metabaseIntegration, verifyTLS, cfAccessClientID, cfAccessClientSecret)
 		if err != nil {
 			return err
 		}
@@ -36,6 +36,8 @@ func MetabaseWorkflow(metabaseIntegration MetabaseIntegration, apiKey, integrati
 		sessionKey,
 		metabaseIntegration.UseAPIKey,
 		verifyTLS,
+		cfAccessClientID,
+		cfAccessClientSecret,
 	)
 	if err != nil {
 		return err


### PR DESCRIPTION
# Description 
Add support for Cloudflare Access headers to bypass application protection when accessing Metabase APIs.

## Background

Some organizations deploy Metabase behind Cloudflare Access for additional security protection. Cloudflare Access requires specific client headers (`CF-Access-Client-Id` and `CF-Access-Client-Secret`) to authenticate and bypass the access control checks.

Without these headers, requests to protected Metabase instances will be blocked by Cloudflare Access, preventing the sync worker from accessing the Metabase API endpoints.

# Changes

  - Added support for CF_ACCESS_CLIENT_ID and CF_ACCESS_CLIENT_SECRET environment variables
  - Modified all Metabase API requests to conditionally include Cloudflare Access headers when the environment variables are provided
  - Updated function signatures to pass the CF Access credentials through the call chain
  - Headers are only added when environment variables are set, ensuring backward compatibility

 # Usage

 Set the following environment variables when running the worker against a Cloudflare Access-protected Metabase instance:
  CF_ACCESS_CLIENT_ID=your_client_id
  CF_ACCESS_CLIENT_SECRET=your_client_secret