### PR TITLE
Support Omni BI Integrations for sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,32 +1,58 @@
-# Formal Metabase Sync Worker
+# Formal BI Sync Worker
 
-This is a worker that syncs the formal metabase with the formal database.
+A worker that syncs users from BI tools (Metabase, Omni) to Formal by mapping user identities via external IDs. Configure one or both integrations — any integration with its required env vars set will be enabled.
 
 ## Usage
 
 First build the docker image:
 
 ```bash
-docker build -t formal-metabase-sync-worker .
+docker build -t formal-bi-sync-worker .
 ```
 
 Then run the docker image:
 
 ```bash
-docker run -e METABASE_HOSTNAME="" -e METABASE_USE_API_KEY="" -e METABASE_API_KEY=""  -e METABASE_USERNAME="" -e METABASE_PASSWORD="" -e METABASE_VERSION="" -e FORMAL_API_KEY="" -e FORMAL_APP_ID="" -e VERIFY_TLS="" -e CF_ACCESS_CLIENT_ID="" -e CF_ACCESS_CLIENT_SECRET="" formal-metabase-sync-worker 
+docker run \
+  -e FORMAL_API_KEY="" \
+  -e VERIFY_TLS="" \
+  -e LOG_LEVEL="" \
+  -e FREQUENCY="" \
+  -e METABASE_HOSTNAME="" \
+  -e METABASE_BI_INTEGRATION_ID="" \
+  -e METABASE_USE_API_KEY="" \
+  -e METABASE_API_KEY="" \
+  -e METABASE_USERNAME="" \
+  -e METABASE_PASSWORD="" \
+  -e METABASE_VERSION="" \
+  -e CF_ACCESS_CLIENT_ID="" \
+  -e CF_ACCESS_CLIENT_SECRET="" \
+  -e OMNI_API_KEY="" \
+  -e OMNI_HOSTNAME="" \
+  -e OMNI_BI_INTEGRATION_ID="" \
+  formal-bi-sync-worker
 ```
 
 ## Environment Variables
-- ```METABASE_USE_API_KEY``` (optional): Whether or not to use the Metabase API key instead of username/password auth. Set to `true` or `false`. Default value is `false`.
-- ```METABASE_API_KEY``` (optional): The API key for the metabase instance; required if not providing username/password auth.
-- ```METABASE_HOSTNAME```: The hostname of the metabase instance 
-- ```METABASE_USERNAME```: (optional) The username of the metabase instance; required if not providing API key.
-- ```METABASE_PASSWORD```: (optional) The password of the metabase instance; required if not providing API key.
-- ```METABASE_VERSION```: The version of the metabase instance (e.g.: 0.35.4)
-- ```FORMAL_API_KEY```: The API key of the formal instance
-- ```FORMAL_APP_ID```: The app id of the Formal Metabase integration
-- ```VERIFY_TLS```: Whether or not to verify the TLS certificate of the Metabase instance. Set to `true` or `false`
-- ```CF_ACCESS_CLIENT_ID``` (optional): Cloudflare Access Client ID for bypassing Cloudflare Access protection on Metabase instances
-- ```CF_ACCESS_CLIENT_SECRET``` (optional): Cloudflare Access Client Secret for bypassing Cloudflare Access protection on Metabase instances
-- ```LOG_LEVEL``` (optional): Set the Global logging level to any of these options: `debug`, `info`, `warn`, `error`, `fatal`, `panic`, `disabled`. Default value is `info`.
-- ```FREQUENCY``` (optional): The frequency at which to run the sync. Expected format: `1h`, `30m`, etc. If not provided, the sync will run once and then exit.
+
+### Formal (required)
+- `FORMAL_API_KEY`: API key for the Formal instance
+- `VERIFY_TLS`: Whether to verify TLS certificates. Set to `true` or `false`
+- `LOG_LEVEL` (optional): Global log level — `debug`, `info`, `warn`, `error`, `fatal`, `panic`, `disabled`. Defaults to `info`
+- `FREQUENCY` (optional): How often to run the sync (e.g. `1h`, `30m`). If not set, runs once and exits
+
+### Metabase (optional — enabled when `METABASE_HOSTNAME` is set)
+- `METABASE_HOSTNAME`: Hostname of the Metabase instance
+- `METABASE_BI_INTEGRATION_ID`: Integration ID of the Formal Metabase integration
+- `METABASE_USE_API_KEY` (optional): Use API key auth instead of username/password. Set to `true` or `false`. Defaults to `false`
+- `METABASE_API_KEY` (optional): Metabase API key; required if `METABASE_USE_API_KEY` is `true`
+- `METABASE_USERNAME` (optional): Metabase username; required if not using API key auth
+- `METABASE_PASSWORD` (optional): Metabase password; required if not using API key auth
+- `METABASE_VERSION`: Version of the Metabase instance (e.g. `0.35.4`)
+- `CF_ACCESS_CLIENT_ID` (optional): Cloudflare Access Client ID for Metabase instances behind Cloudflare Access
+- `CF_ACCESS_CLIENT_SECRET` (optional): Cloudflare Access Client Secret for Metabase instances behind Cloudflare Access
+
+### Omni (optional — enabled when both `OMNI_API_KEY` and `OMNI_HOSTNAME` are set)
+- `OMNI_API_KEY`: Omni organization API key
+- `OMNI_HOSTNAME`: Hostname of the Omni instance (e.g. `myorg.omniapp.co`)
+- `OMNI_BI_INTEGRATION_ID`: Integration ID of the Formal Omni BI integration

--- a/formal.go
+++ b/formal.go
@@ -31,7 +31,7 @@ type Client struct {
 }
 
 const (
-	FORMAL_HOST_URL string = "https://v2api.formalcloud.net"
+	FORMAL_HOST_URL string = "https://api.joinformal.com"
 )
 
 func (t *transport) RoundTrip(req *http.Request) (*http.Response, error) {
@@ -96,12 +96,12 @@ func (c *Client) ListHumanFormalUsers() ([]User, error) {
 	return users, nil
 }
 
-func (c *Client) MapUserToExternalId(userId, metabaseUserExternalId, integrationID string) error {
+func (c *Client) CreateUserExternalId(userId, externalId, integrationID, description string) error {
 	_, err := c.client.CreateUserExternalId(context.Background(), connect.NewRequest(&corev1.CreateUserExternalIdRequest{
 		UserId:      userId,
-		ExternalId:  metabaseUserExternalId,
+		ExternalId:  externalId,
 		AppId:       integrationID,
-		Description: "This External ID was imported for this role via Metabase.",
+		Description: description,
 	}))
 	if err != nil {
 		return err

--- a/main.go
+++ b/main.go
@@ -10,21 +10,7 @@ import (
 )
 
 func main() {
-	metabaseUseApiKey, err := strconv.ParseBool(os.Getenv("METABASE_USE_API_KEY"))
-	if err != nil {
-		metabaseUseApiKey = false
-	}
-
-	metabaseIntegration := MetabaseIntegration{
-		UseAPIKey:        metabaseUseApiKey,
-		MetabaseAPIKey:   os.Getenv("METABASE_API_KEY"),
-		MetabaseHostname: os.Getenv("METABASE_HOSTNAME"),
-		MetabaseUsername: os.Getenv("METABASE_USERNAME"),
-		MetabasePwd:      os.Getenv("METABASE_PASSWORD"),
-		Version:          os.Getenv("METABASE_VERSION"),
-	}
 	formalAPIKey := os.Getenv("FORMAL_API_KEY")
-	integrationID := os.Getenv("FORMAL_APP_ID")
 	verifyTLS, err := strconv.ParseBool(os.Getenv("VERIFY_TLS"))
 	if err != nil {
 		log.Warn().Msg("Invalid VERIFY_TLS value, defaulting to true")
@@ -61,16 +47,75 @@ func main() {
 		}
 	}
 
-	// Cloudflare Access headers
 	cfAccessClientID := os.Getenv("CF_ACCESS_CLIENT_ID")
 	cfAccessClientSecret := os.Getenv("CF_ACCESS_CLIENT_SECRET")
 
-	for {
-		log.Info().Msg("Starting Metabase sync")
-		err = MetabaseWorkflow(metabaseIntegration, formalAPIKey, integrationID, verifyTLS, cfAccessClientID, cfAccessClientSecret)
+	var metabaseEnabled bool
+	var metabaseIntegration MetabaseIntegration
+	metabaseHostname := os.Getenv("METABASE_HOSTNAME")
+	if metabaseHostname != "" {
+		metabaseUseApiKey, err := strconv.ParseBool(os.Getenv("METABASE_USE_API_KEY"))
 		if err != nil {
-			log.Error().Err(err).Msg("Sync failed")
+			metabaseUseApiKey = false
 		}
+		metabaseIntegration = MetabaseIntegration{
+			UseAPIKey:        metabaseUseApiKey,
+			MetabaseAPIKey:   os.Getenv("METABASE_API_KEY"),
+			MetabaseHostname: metabaseHostname,
+			MetabaseUsername: os.Getenv("METABASE_USERNAME"),
+			MetabasePwd:      os.Getenv("METABASE_PASSWORD"),
+			Version:          os.Getenv("METABASE_VERSION"),
+		}
+		metabaseEnabled = true
+		log.Info().Str("hostname", metabaseHostname).Msg("Metabase sync enabled")
+	}
+
+	var omniEnabled bool
+	var omniIntegration OmniIntegration
+	omniAPIKey := os.Getenv("OMNI_API_KEY")
+	omniHostname := os.Getenv("OMNI_HOSTNAME")
+	if omniAPIKey != "" && omniHostname != "" {
+		omniIntegration = OmniIntegration{
+			APIKey:        omniAPIKey,
+			Hostname:      omniHostname,
+			IntegrationID: os.Getenv("OMNI_BI_INTEGRATION_ID"),
+		}
+		omniEnabled = true
+		log.Info().Str("hostname", omniHostname).Msg("Omni sync enabled")
+	}
+
+	if !metabaseEnabled && !omniEnabled {
+		log.Fatal().Msg("No integrations configured. Set METABASE_HOSTNAME for Metabase or OMNI_API_KEY and OMNI_HOSTNAME for Omni.")
+	}
+
+	formalClient := New(formalAPIKey)
+
+	for {
+		log.Info().Msg("Fetching users from Formal")
+		users, err := formalClient.ListHumanFormalUsers()
+		if err != nil {
+			log.Error().Err(err).Msg("Failed to fetch Formal users")
+		} else {
+			log.Info().Int("count", len(users)).Msg("Fetched users from Formal")
+
+			if metabaseEnabled {
+				log.Info().Msg("Starting Metabase sync")
+				metabaseIntegrationID := os.Getenv("METABASE_BI_INTEGRATION_ID")
+				err = MetabaseWorkflow(metabaseIntegration, formalClient, users, metabaseIntegrationID, verifyTLS, cfAccessClientID, cfAccessClientSecret)
+				if err != nil {
+					log.Error().Err(err).Msg("Metabase sync failed")
+				}
+			}
+
+			if omniEnabled {
+				log.Info().Msg("Starting Omni sync")
+				err = OmniWorkflow(omniIntegration, formalClient, users)
+				if err != nil {
+					log.Error().Err(err).Msg("Omni sync failed")
+				}
+			}
+		}
+
 		if frequency == "" {
 			break
 		}

--- a/omni_api.go
+++ b/omni_api.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/rs/zerolog/log"
+)
+
+type OmniSCIMResponse struct {
+	Resources    []OmniUser `json:"Resources"`
+	TotalResults int        `json:"totalResults"`
+	StartIndex   int        `json:"startIndex"`
+	ItemsPerPage int        `json:"itemsPerPage"`
+}
+
+type OmniUser struct {
+	Id       string `json:"id"`
+	UserName string `json:"userName"`
+	Active   bool   `json:"active"`
+}
+
+func GetOmniUsers(hostname, apiKey string) (map[string]OmniUser, error) {
+	baseURL := "https://" + hostname + "/api/scim/v2/users"
+	users := map[string]OmniUser{}
+	startIndex := 1
+	count := 100
+
+	httpClient := &http.Client{Timeout: 30 * time.Second}
+
+	for {
+		url := baseURL + "?startIndex=" + strconv.Itoa(startIndex) + "&count=" + strconv.Itoa(count)
+		req, err := http.NewRequest("GET", url, nil)
+		if err != nil {
+			return nil, err
+		}
+		req.Header.Set("Authorization", "Bearer "+apiKey)
+		req.Header.Set("Content-Type", "application/json")
+
+		resp, err := httpClient.Do(req)
+		if err != nil {
+			return nil, err
+		}
+
+		body, err := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		if err != nil {
+			return nil, err
+		}
+
+		if resp.StatusCode != http.StatusOK {
+			log.Debug().Str("body", string(body)).Int("status", resp.StatusCode).Msg("Unexpected response from Omni API")
+			return nil, errors.New("Omni API returned status " + strconv.Itoa(resp.StatusCode))
+		}
+
+		var response OmniSCIMResponse
+		err = json.Unmarshal(body, &response)
+		if err != nil {
+			log.Debug().Str("body", string(body)).Msg("Failed to parse Omni API response")
+			return nil, err
+		}
+
+		for _, user := range response.Resources {
+			users[user.UserName] = user
+		}
+
+		if startIndex+len(response.Resources) > response.TotalResults {
+			break
+		}
+		startIndex += len(response.Resources)
+	}
+
+	return users, nil
+}

--- a/workflow.go
+++ b/workflow.go
@@ -16,9 +16,13 @@ type MetabaseIntegration struct {
 	Version          string
 }
 
-func MetabaseWorkflow(metabaseIntegration MetabaseIntegration, apiKey, integrationID string, verifyTLS bool, cfAccessClientID, cfAccessClientSecret string) error {
-	client := New(apiKey)
+type OmniIntegration struct {
+	APIKey        string
+	Hostname      string
+	IntegrationID string
+}
 
+func MetabaseWorkflow(metabaseIntegration MetabaseIntegration, formalClient *Client, users []User, integrationID string, verifyTLS bool, cfAccessClientID, cfAccessClientSecret string) error {
 	sessionKey := ""
 
 	if !metabaseIntegration.UseAPIKey {
@@ -47,13 +51,6 @@ func MetabaseWorkflow(metabaseIntegration MetabaseIntegration, apiKey, integrati
 	}
 	log.Info().Int("count", len(metabaseRoles)).Msg("Fetched users from Metabase")
 
-	log.Info().Msg("Fetching users from Formal")
-	users, err := client.ListHumanFormalUsers()
-	if err != nil {
-		return fmt.Errorf("failed to fetch Formal users: %w", err)
-	}
-	log.Info().Int("count", len(users)).Msg("Fetched users from Formal")
-
 	log.Info().Msg("Mapping Metabase users to Formal users")
 	mappedUserCount := 0
 	skippedUserCount := 0
@@ -74,7 +71,7 @@ func MetabaseWorkflow(metabaseIntegration MetabaseIntegration, apiKey, integrati
 				continue
 			}
 
-			err = client.MapUserToExternalId(user.Id, metabaseUserExternalId, integrationID)
+			err = formalClient.CreateUserExternalId(user.Id, metabaseUserExternalId, integrationID, "This External ID was imported for this user via Metabase.")
 			if err != nil {
 				return fmt.Errorf("failed to map user %s: %w", user.Email, err)
 			}
@@ -82,6 +79,46 @@ func MetabaseWorkflow(metabaseIntegration MetabaseIntegration, apiKey, integrati
 			mappedUserCount++
 		}
 	}
-	log.Info().Int("mapped", mappedUserCount).Int("skipped", skippedUserCount).Msg("Sync completed")
+	log.Info().Int("mapped", mappedUserCount).Int("skipped", skippedUserCount).Msg("Metabase sync completed")
+	return nil
+}
+
+func OmniWorkflow(omniIntegration OmniIntegration, formalClient *Client, users []User) error {
+	log.Info().Str("hostname", omniIntegration.Hostname).Msg("Fetching users from Omni")
+	omniUsers, err := GetOmniUsers(omniIntegration.Hostname, omniIntegration.APIKey)
+	if err != nil {
+		return fmt.Errorf("failed to fetch Omni users: %w", err)
+	}
+	log.Info().Int("count", len(omniUsers)).Msg("Fetched users from Omni")
+
+	log.Info().Msg("Mapping Omni users to Formal users")
+	mappedUserCount := 0
+	skippedUserCount := 0
+	for _, user := range users {
+		omniUser, exists := omniUsers[user.Email]
+		if exists {
+			omniUserExternalId := omniUser.Id
+			alreadyMapped := false
+			for _, existingExternalId := range user.ExternalIds {
+				if existingExternalId.ExternalId == omniUserExternalId && existingExternalId.AppId == omniIntegration.IntegrationID {
+					alreadyMapped = true
+					break
+				}
+			}
+			if alreadyMapped {
+				log.Debug().Str("email", user.Email).Str("external_id", omniUserExternalId).Msg("User already mapped, skipping")
+				skippedUserCount++
+				continue
+			}
+
+			err = formalClient.CreateUserExternalId(user.Id, omniUserExternalId, omniIntegration.IntegrationID, "This External ID was imported for this user via Omni.")
+			if err != nil {
+				return fmt.Errorf("failed to map user %s: %w", user.Email, err)
+			}
+			log.Debug().Str("email", user.Email).Str("external_id", omniUserExternalId).Msg("Mapped user")
+			mappedUserCount++
+		}
+	}
+	log.Info().Int("mapped", mappedUserCount).Int("skipped", skippedUserCount).Msg("Omni sync completed")
 	return nil
 }


### PR DESCRIPTION
Support Omni BI Integrations in the sync worker.

For now, don't rename the git repo and ECR repo even though this repo is going beyond just metabase.

Note: this is a breaking change since we rename some environment variables: users who upgrade their ECR repo version will have to rename some existing environment variables.